### PR TITLE
Add dev flag

### DIFF
--- a/src/Auth0AutoRest.csproj
+++ b/src/Auth0AutoRest.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard1.6</TargetFrameworks>
     <PackageId>Nutonomy.Auth0AutoRest</PackageId>
-    <PackageVersion>1.1.0</PackageVersion>
+    <PackageVersion>1.2.0</PackageVersion>
     <Authors>Nutonomy</Authors>
     <Description>AutoRest compatible TokenProvider</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/src/Auth0Provider.cs
+++ b/src/Auth0Provider.cs
@@ -14,32 +14,40 @@ namespace Auth0AutoRest
         private readonly Auth0TokenRequest _auth0TokenRequest;
         private Auth0TokenResponse _cachedToken;
         private DateTime _expiry;
+        private bool _isAuthRequired;
 
-        public Auth0Provider(Auth0TokenRequest auth0TokenRequest) : this(auth0TokenRequest, TimeSpan.FromMinutes(10))
+        public Auth0Provider(Auth0TokenRequest auth0TokenRequest, bool isAuthRequired = true) : this(auth0TokenRequest, TimeSpan.FromMinutes(10), isAuthRequired)
         {
         }
 
-        public Auth0Provider(Auth0TokenRequest auth0TokenRequest, TimeSpan tokenTimeout)
+        public Auth0Provider(Auth0TokenRequest auth0TokenRequest, TimeSpan tokenTimeout, bool isAuthRequired = true)
         {
             TokenTimeout = tokenTimeout;
             _auth0TokenRequest = auth0TokenRequest;
+            _isAuthRequired = isAuthRequired;
         }
 
         public async Task<AuthenticationHeaderValue> GetAuthenticationHeaderAsync(CancellationToken cancellationToken)
         {
-            if (_cachedToken == null || DateTime.UtcNow + TokenTimeout > _expiry)
+            if (_isAuthRequired)
             {
-                var tokenResponse = await _auth0TokenRequest.Auth0Endpoint
-                    .PostJsonAsync(_auth0TokenRequest)
-                    .ReceiveJson<Auth0TokenResponse>();
+                if (_cachedToken == null || DateTime.UtcNow + TokenTimeout > _expiry)
+                {
+                    var tokenResponse = await _auth0TokenRequest.Auth0Endpoint
+                        .PostJsonAsync(_auth0TokenRequest)
+                        .ReceiveJson<Auth0TokenResponse>();
 
-                var exp = new JwtSecurityTokenHandler().ReadJwtToken(tokenResponse.AccessToken).Payload.Exp;
-                var offset = exp == null ? 0 : (long) exp;
-                _expiry = DateTimeOffset.FromUnixTimeSeconds(offset).UtcDateTime;
-                _cachedToken = tokenResponse;
+                    var exp = new JwtSecurityTokenHandler().ReadJwtToken(tokenResponse.AccessToken).Payload.Exp;
+                    var offset = exp == null ? 0 : (long) exp;
+                    _expiry = DateTimeOffset.FromUnixTimeSeconds(offset).UtcDateTime;
+                    _cachedToken = tokenResponse;
+                }
+                return _cachedToken.AuthenticationHeader;
             }
-
-            return _cachedToken.AuthenticationHeader;
+            else
+            {
+                return new AuthenticationHeaderValue("Bearer", "Not getting token from Auth0 when isAuthRequired=false (env=Development)");
+            }
         }
     }
 }

--- a/src/Auth0Provider.cs
+++ b/src/Auth0Provider.cs
@@ -31,6 +31,7 @@ namespace Auth0AutoRest
         {
             if (_isAuthRequired)
             {
+                // only renew token if it is nearing expiry
                 if (_cachedToken == null || DateTime.UtcNow + TokenTimeout > _expiry)
                 {
                     var tokenResponse = await _auth0TokenRequest.Auth0Endpoint

--- a/test/Auth0AutoRestTest.cs
+++ b/test/Auth0AutoRestTest.cs
@@ -28,7 +28,7 @@ namespace Auth0AutoRestTest
                 ClientSecret = ClientSecret,
                 Audience = Audience,
                 Auth0Endpoint = "https://test.auth0.com/oauth/token"
-            });
+            }, true);
 
             var rand = new RNGCryptoServiceProvider();
             var randBytes = new byte[16];


### PR DESCRIPTION
Users can now specify to bypass auth0 and return a nonsense bearer token while in a development environment.

Updated to 1.2.0