### PR TITLE
Cache token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,5 @@ artifacts/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+
+.vscode

--- a/src/Auth0AutoRest.csproj
+++ b/src/Auth0AutoRest.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard1.6</TargetFrameworks>
     <PackageId>Nutonomy.Auth0AutoRest</PackageId>
-    <PackageVersion>1.2.0</PackageVersion>
+    <PackageVersion>1.3.0</PackageVersion>
     <Authors>Nutonomy</Authors>
     <Description>AutoRest compatible TokenProvider</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/src/Auth0Provider.cs
+++ b/src/Auth0Provider.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.IO;
 using System.IdentityModel.Tokens.Jwt;
 using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using Flurl.Http;
 using Microsoft.Rest;
+using Newtonsoft.Json;
 
 namespace Auth0AutoRest
 {
@@ -15,7 +17,7 @@ namespace Auth0AutoRest
         private Auth0TokenResponse _cachedToken;
         private DateTime _expiry;
         private bool _isAuthRequired;
-
+        private readonly string _cachedTokenResponse = @"/tmp/tokenResponse.json";
         public Auth0Provider(Auth0TokenRequest auth0TokenRequest, bool isAuthRequired = true) : this(auth0TokenRequest, TimeSpan.FromMinutes(10), isAuthRequired)
         {
         }
@@ -27,20 +29,46 @@ namespace Auth0AutoRest
             _isAuthRequired = isAuthRequired;
         }
 
+        private DateTime GetExpiry(Auth0TokenResponse tokenResponse)
+        {
+            var exp = new JwtSecurityTokenHandler().ReadJwtToken(tokenResponse.AccessToken).Payload.Exp;
+            var offset = exp == null ? 0 : (long)exp;
+            return DateTimeOffset.FromUnixTimeSeconds(offset).UtcDateTime;
+        }
+
         public async Task<AuthenticationHeaderValue> GetAuthenticationHeaderAsync(CancellationToken cancellationToken)
         {
             if (_isAuthRequired)
             {
-                // only renew token if it is nearing expiry
+                if (_cachedToken == null)
+                {
+                    // get token if found in tmp folder
+                    if (File.Exists(_cachedTokenResponse))
+                    {
+                        using (var streamReader = new StreamReader(_cachedTokenResponse))
+                        {
+                            var responseJson = streamReader.ReadToEnd();
+                            try
+                            {
+                                var cachedTokenResponse = JsonConvert.DeserializeObject<Auth0TokenResponse>(responseJson);
+                                _expiry = GetExpiry(cachedTokenResponse);
+                                _cachedToken = cachedTokenResponse;
+                            }
+                            catch (Exception)
+                            { }
+                        }
+                    }
+                }
+
+                // only renew token if doesn't exist in cache or tmp folder or if it is nearing expiry
                 if (_cachedToken == null || DateTime.UtcNow + TokenTimeout > _expiry)
                 {
                     var tokenResponse = await _auth0TokenRequest.Auth0Endpoint
                         .PostJsonAsync(_auth0TokenRequest)
                         .ReceiveJson<Auth0TokenResponse>();
-
-                    var exp = new JwtSecurityTokenHandler().ReadJwtToken(tokenResponse.AccessToken).Payload.Exp;
-                    var offset = exp == null ? 0 : (long) exp;
-                    _expiry = DateTimeOffset.FromUnixTimeSeconds(offset).UtcDateTime;
+                    var jsonString = JsonConvert.SerializeObject(tokenResponse);
+                    File.WriteAllText(_cachedTokenResponse, jsonString);
+                    _expiry = GetExpiry(tokenResponse);
                     _cachedToken = tokenResponse;
                 }
                 return _cachedToken.AuthenticationHeader;

--- a/src/Auth0Provider.cs
+++ b/src/Auth0Provider.cs
@@ -67,7 +67,10 @@ namespace Auth0AutoRest
                         .PostJsonAsync(_auth0TokenRequest)
                         .ReceiveJson<Auth0TokenResponse>();
                     var jsonString = JsonConvert.SerializeObject(tokenResponse);
-                    File.WriteAllText(_cachedTokenResponse, jsonString);
+                    if (Directory.Exists(@"/tmp"))
+                    {
+                        File.WriteAllText(_cachedTokenResponse, jsonString);
+                    }
                     _expiry = GetExpiry(tokenResponse);
                     _cachedToken = tokenResponse;
                 }


### PR DESCRIPTION
Caching token request into `/tmp` folder. Tested locally with staging auth.
Should i create a folder for this in nuCloud so the rest can review?